### PR TITLE
fixed a bug that caused the player to level up if the given xp was at…

### DIFF
--- a/public/main/private/game.js
+++ b/public/main/private/game.js
@@ -306,12 +306,9 @@ var gainMoney = function () {
 *   xp bar is updated
 */  
 var gainXP = function () {
-    if (player.xp + pokemon.baseXP < player.nextLevelXP) {
-        player.xp += pokemon.baseXP;
-    }
-
-    if (player.xp + pokemon.baseXP >= player.nextLevelXP) {
-        player.xp += pokemon.baseXP;
+    player.xp += pokemon.baseXP;
+    if (player.xp >= player.nextLevelXP) {
+        
         while (player.xp >= player.nextLevelXP) {
             player.level++;
             player.xp -= player.nextLevelXP;


### PR DESCRIPTION
… least half the missing xp, instead of leveling up when given xp was at least equal the to missing xp, caused by a missplaced if clause